### PR TITLE
Update bladebit.py - fixing n in --check <n>

### DIFF
--- a/src/plotman/plotters/bladebit.py
+++ b/src/plotman/plotters/bladebit.py
@@ -35,8 +35,8 @@ class Options:
     disk_128: bool = False
     disk_16: bool = False
     no_direct_io: bool = False
-    check_plot: bool = False                # Perform a plot check for <n> proofs on the newly created plot.
-    check-threshold: bool = False           # Proof threshold rate below which the plots that don't pass the check will be deleted.  That is, the number of proofs fetched / proof check count  must be above or equal to this threshold to pass. (default=0.6).
+    check_plots: typing.Optional[int] = None
+    check_threshold: typing.Optional[int] = None
 
     def chosen_executable(self) -> str:
         if self.mode == 'gpuplot':
@@ -154,11 +154,13 @@ def create_command_line(
         if options.disk_128:
             args.append("--disk-128")
         elif options.disk_16:
-            args.append("--disk-16")
-            
-    if options.mode == "gpuplot" and options.check_plot:
-            args.append("--check 100")
-            # args.append("--check-threshold 0.6")   # Automated plot deletion when plotcheck threshhold is below 0.6. Not yet used by us.
+            args.append("--disk-16")     
+        if options.check_plots:
+            args.append("--check")
+            args.append(str(options.check_plots))
+        if options.check_threshold:
+            args.append("--check-threshold")
+            args.append(str(options.check_threshold))
 
     if options.mode == 'diskplot' and tmpdir is not None:
         args.append("-t1")
@@ -1333,7 +1335,12 @@ def _cli_a85283946c56b5ae1e5b673f62143417db96247b() -> None:
 )
 @click.option(
     "--check",
-    help="UNDOCUMENTED FEATURE: On cudaplot, allow plots to be checked via the --check <n> parameter.",
+    help="UNDOCUMENTED FEATURE: On cudaplot, allow plots to be checked via the --check <n> parameter. Try n=100 to start.",
+    type=int,
+)
+@click.option(
+    "--check-threshold",
+    help="UNDOCUMENTED FEATURE: On cudaplot, delete plots that don't check as valid after creation, based on threshold between 0 and 1.",
     type=int,
 )
 @click.argument(

--- a/src/plotman/plotters/bladebit.py
+++ b/src/plotman/plotters/bladebit.py
@@ -35,7 +35,8 @@ class Options:
     disk_128: bool = False
     disk_16: bool = False
     no_direct_io: bool = False
-    check_plots: bool = False 
+    check_plot: bool = False                # Perform a plot check for <n> proofs on the newly created plot.
+    check-threshold: bool = False           # Proof threshold rate below which the plots that don't pass the check will be deleted.  That is, the number of proofs fetched / proof check count  must be above or equal to this threshold to pass. (default=0.6).
 
     def chosen_executable(self) -> str:
         if self.mode == 'gpuplot':
@@ -154,8 +155,10 @@ def create_command_line(
             args.append("--disk-128")
         elif options.disk_16:
             args.append("--disk-16")
-        if options.check_plots:
-            args.append("--check 1")
+            
+    if options.mode == "gpuplot" and options.check_plot:
+            args.append("--check 100")
+            # args.append("--check-threshold 0.6")   # Automated plot deletion when plotcheck threshhold is below 0.6. Not yet used by us.
 
     if options.mode == 'diskplot' and tmpdir is not None:
         args.append("-t1")


### PR DESCRIPTION
-fixing an issue in --check <n> when before value was 1 and way to little. Updated value: 100

-added plot deletion feature when plot checking fails. WARNING: This feature is currently uncommented and not used.


fixing an issue with plotting not starting when argument --check was not enabled. Hopefully this works now. 
@guydavis if you are curious abut this --check feature you can read more here: https://chiaforum.com/t/bladebit-gpu-plotter-beta/19119/594   Comment is at Sep23

Please check my editing for typos or bad code